### PR TITLE
fix unit search path for admin overrides

### DIFF
--- a/manifests/unit.pp
+++ b/manifests/unit.pp
@@ -11,7 +11,7 @@ define systemd::unit (
 ) {
 
 
-  $unit_path        = '/usr/lib/systemd/system'
+  $unit_path        = '/etc/systemd/system'
 
 
 


### PR DESCRIPTION
Respects the search path for unit files: http://www.freedesktop.org/software/systemd/man/systemd.unit.html
